### PR TITLE
Add workflow to build gradle-next

### DIFF
--- a/.github/workflows/install-gradle-next.yml
+++ b/.github/workflows/install-gradle-next.yml
@@ -1,0 +1,47 @@
+name: Install Gradle Next
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # Enable debug for the `gradle-build-action` cache operations
+  GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+
+jobs:
+  build:
+    name: "Install"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: git clone
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: install
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+          build-root-directory: gradle-next
+          arguments: |
+            install
+            -Pgradle_installPath=gradle-next-install
+            :distributions-full:binDistributionZip
+            --no-configuration-cache
+            -DdisableLocalCache=true
+            -DagreePublicBuildScanTermOfService=yes
+            -DcacheNode=us
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gradle-next.zip
+          path: gradle-next/subprojects/distributions-full/build/distributions/gradle-*-bin.zip
+


### PR DESCRIPTION
This adds a first workflow to run some automatic builds on this repository. It starts out with building the `gradle-next` distribution.