### PR TITLE
Add some build logic to demonstrate source pinning

### DIFF
--- a/simple-java-groovy-dsl/buildSrc/build.gradle
+++ b/simple-java-groovy-dsl/buildSrc/build.gradle
@@ -13,3 +13,8 @@ repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
 }
+
+@groovy.transform.CompileStatic
+def enabledIncompatibleMethod(Task task) {
+    task.doNotTrackState("Introduced in Gradle 7.3")
+}

--- a/simple-java-groovy-dsl/buildSrc/src/main/groovy/provider.simple.java.java-incompatible-with-old-conventions.gradle
+++ b/simple-java-groovy-dsl/buildSrc/src/main/groovy/provider.simple.java.java-incompatible-with-old-conventions.gradle
@@ -1,0 +1,5 @@
+
+@groovy.transform.CompileStatic
+def enabledIncompatibleMethod(Task task) {
+    task.doNotTrackState("Introduced in Gradle 7.3")
+}

--- a/simple-java-groovy-dsl/buildSrc/src/main/groovy/provider/simple/java/UsingNewApi.groovy
+++ b/simple-java-groovy-dsl/buildSrc/src/main/groovy/provider/simple/java/UsingNewApi.groovy
@@ -1,0 +1,11 @@
+package provider.simple.java;
+
+import groovy.transform.CompileStatic;
+import org.gradle.api.Task;
+
+@CompileStatic
+class UsingNewApi {
+    static enabledIncompatibleMethod(Task task) {
+        task.doNotTrackState("Introduced in Gradle 7.3")
+    }
+}

--- a/simple-kotlin-kotlin-dsl/buildSrc/build.gradle.kts
+++ b/simple-kotlin-kotlin-dsl/buildSrc/build.gradle.kts
@@ -17,3 +17,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
 }
+
+fun Task.doSomeStuff() {
+    doNotTrackState("Introduced in Gradle 7.3")
+}

--- a/simple-kotlin-kotlin-dsl/buildSrc/src/main/kotlin/provider.simple.kotlin.incompatible-with-old-conventions.gradle.kts
+++ b/simple-kotlin-kotlin-dsl/buildSrc/src/main/kotlin/provider.simple.kotlin.incompatible-with-old-conventions.gradle.kts
@@ -1,0 +1,3 @@
+fun Task.doSomeStuff() {
+    doNotTrackState("Introduced in Gradle 7.3")
+}

--- a/simple-kotlin-kotlin-dsl/buildSrc/src/main/kotlin/provider/simple/kotlin/UsingNewApi.kt
+++ b/simple-kotlin-kotlin-dsl/buildSrc/src/main/kotlin/provider/simple/kotlin/UsingNewApi.kt
@@ -1,0 +1,9 @@
+package provider.simple.kotlin
+
+import org.gradle.api.Task
+
+class UsingNewApi {
+    fun Task.useNewApi() {
+        doNotTrackState("Introduced in Gradle 7.3")
+    }
+}


### PR DESCRIPTION
This adds some
- Groovy/Kotlin pre-compiled script
- Groovy/Kotlin build script
- Groovy/Kotlin class

which compile statically against the method `Task.doNotTrackState()`.

This allows trying out source pinning by using a distribution from https://github.com/gradle/gradle/pull/20373.

For example, running the distribution in one of `simple-kotlin-kotlin-dsl` or `simple-java-groovy-dsl` will show that when using an older version for the source Gradle API, then it won't compile:

```
grl -Dorg.gradle.api.source-version=6.9 -Dgradle.api.repository.url=file:///<path-to-provider-api-migration-testbed>/gradle-repository/build/repo help
```

For doing the above, you first need to create the gradle API dependency as described in the README: https://github.com/gradle/provider-api-migration-testbed/tree/main/gradle-repository